### PR TITLE
Endra sortering av synkandeSmitteArr, slik at han ikkje brukar .reverse().

### DIFF
--- a/Oppgåve 1/code.js
+++ b/Oppgåve 1/code.js
@@ -168,8 +168,7 @@ function vurderSmitte() {
     // link https://stackoverflow.com/questions/9592740/how-can-you-sort-an-array-without-mutating-the-original-array
     // link https://www.javatpoint.com/javascript-array-reverse-method
     const stigandeSmitteArr = [...aktuellSmitte].sort((a, b) => a - b);
-    const synkandeSmitteArr = [...aktuellSmitte].sort((a, b) => a - b).reverse();
-    
+    const synkandeSmitteArr = [...aktuellSmitte].sort((a, b) => b - a);
     // Dersom den originale smitten er lik den sorterte smitten, er smitten stigande eller synkande
     // link https://stackoverflow.com/questions/7837456/how-to-compare-arrays-in-javascript
 


### PR DESCRIPTION
`synkandeSmitteArr` var definert som `[...aktutellSmitte].sort((a, b) => a - b).reverse()`. Dette sorterer fyrst i stigande rekkjefølg, og reverserer etterpå. Ved å endre til `[...aktuellSmitte].sort((a, b) => b - a)`, sorterast arrayen synkande i utgangspunktet.

CLOSES #24 